### PR TITLE
Replace playlabs with bigsudo in one-shot execution example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ Requirements
 
 ## Some examples of the installing current role
 
-With [playlabs](https://yourlabs.io/oss/playlabs) you can install this role with just one command, ie:
+Install with galaxy so that you can use with your playbook:
 
-    playlabs install lean_delivery.gitlab_runner @localhost gitlab_ci_token=yourcommand gitlab_host=yourlabs.io gitlab_runner_limit=4 gitlab_version=11.6 
+    ansible-galaxy install lean_delivery.gitlab-runner
 
-Or, without playlabs, install with galaxy so that you can use with your playbook:
+Or without playbook, [bigsudo](https://pypi.org/project/bigsudo) can apply
+this role in one-shot, ie:
 
-ansible-galaxy install lean_delivery.gitlab-runner
+    # note that this will automatically run the ansible-galaxy install command
+    bigsudo install lean_delivery.gitlab_runner @localhost gitlab_ci_token=yourcommand gitlab_host=yourlabs.io gitlab_runner_limit=4 gitlab_version=11.6
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requirements
 ------------
 
  - Version of the ansible for installation: 2.5
- - **Supported OS**:  
+ - **Supported OS**:
    - EL
      - 7
    - Ubuntu
@@ -27,40 +27,40 @@ Requirements
 ## Role Variables
 
 - required
-  - `gitlab_version`  
+  - `gitlab_version`
   Specific version of Gitlab-Runner. Default value is `10.5`.
   - `gitlab_ci_token`
   A Token you obtained to register the Runner. Default value is ``.
 
 - defaults
-  - `gitlab_runner_skip_registration`  
-  Skip gitlab-runner registration after installation. Default value is `False`    
-  - `gitlab_host`  
+  - `gitlab_runner_skip_registration`
+  Skip gitlab-runner registration after installation. Default value is `False`
+  - `gitlab_host`
   Docker gitlab server. Default value is `git.epam.com`
-  - `gitlab_runner_tags`  
+  - `gitlab_runner_tags`
   The tags associated with the Runner. Should be comma delimited. Default value is `delegated`
-  - `gitlab_runner_untagged_builds_run`  
+  - `gitlab_runner_untagged_builds_run`
   Config that prevents it from picking untagged jobs. Default value is `False`
-  - `gitlab_runner_lock_to_project`  
+  - `gitlab_runner_lock_to_project`
   Config that lock the Runner to current project. Default value is `False`
-  - `gitlab_runner_executor`  
+  - `gitlab_runner_executor`
   Runner executor. Default value is `shell`
-  - `gitlab_runner_extra_options`  
-  Extra option for runner registration process. Default value is `undefined`  
-  - `gitlab_runner_limit`  
+  - `gitlab_runner_extra_options`
+  Extra option for runner registration process. Default value is `undefined`
+  - `gitlab_runner_limit`
   Config that Limit how many jobs can be handled concurrently by this token. `0` simply means don't limit. Default value is `1`
-  - `gitlab_runner_concurrent`  
+  - `gitlab_runner_concurrent`
   Limits how many jobs globally can be run concurrently.
-  The most upper limit of jobs using all defined runners. 
+  The most upper limit of jobs using all defined runners.
   0 does not mean unlimited. Default value is `ansible_processor_vcpus`
-  - `gitlab_runner_request_concurrency`  
+  - `gitlab_runner_request_concurrency`
   Limit number of concurrent requests for new jobs from GitLab. Default value is `1`
-  - `gitlab_runner_env_vars`  
+  - `gitlab_runner_env_vars`
   Append or overwrite environment variables. Default value is `["ENV=value", "LC_ALL=en_US.UTF-8"]`
-  - `packages_additional`  
+  - `packages_additional`
   Install additional packages for all installs. Default value is `[]`
-  - `gitlab_runner_gpg`  
-  GPG key for Debian. Default value is `https://packages.gitlab.com/gpg.key`  
+  - `gitlab_runner_gpg`
+  GPG key for Debian. Default value is `https://packages.gitlab.com/gpg.key`
 
 ## Some examples of the installing current role
 


### PR DESCRIPTION
    Replace playlabs with bigsudo

    Playlabs is a monorepo that is being extracted into multiple repos. As
    such, we now benefit from a much more lightweight package to acheive the
    same goal: one-shot execution.
