### PR TITLE
feature: add access level and locked configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ gitlab-runner role
 
 [![License](https://img.shields.io/badge/license-Apache-green.svg?style=flat)](https://raw.githubusercontent.com/lean-delivery/ansible-role-gitlab-runner/master/LICENSE)
 [![Build Status](https://travis-ci.org/lean-delivery/ansible-role-gitlab-runner.svg?branch=master)](https://travis-ci.org/lean-delivery/ansible-role-gitlab-runner)
-[![Build Status](https://gitlab.com/lean-delivery/ansible-role-gitlab-runner/badges/master/build.svg)](https://gitlab.com/lean-delivery/ansible-role-gitlab-runner/pipelines)
+[![Build Status](https://gitlab.com/lean-delivery/ansible-role-gitlab-runner/badges/master/pipeline.svg)](https://gitlab.com/lean-delivery/ansible-role-gitlab-runner/pipelines)
 [![Galaxy](https://img.shields.io/badge/galaxy-lean__delivery.gitlab__runner-blue.svg)](https://galaxy.ansible.com/lean_delivery/gitlab_runner)
 ![Ansible](https://img.shields.io/ansible/role/d/29089.svg)
 ![Ansible](https://img.shields.io/badge/dynamic/json.svg?label=min_ansible_version&url=https%3A%2F%2Fgalaxy.ansible.com%2Fapi%2Fv1%2Froles%2F29089%2F&query=$.min_ansible_version)
@@ -56,6 +56,8 @@ Requirements
   Gitlab url address. Default value: `https://{{ gitlab_host }}/`
   - `gitlab_runner_tags`  
   The tags associated with the Runner. Should be comma delimited. Default value is `delegated`
+  - `gitlab_runner_access_level: not_protected`  
+  Determines if a runner can pick up jobs from protected branches. Available values: `ref_protected` `not_protected` Default value is `not_protected`
   - `gitlab_runner_untagged_builds_run`  
   Config that prevents it from picking untagged jobs. Default value is `false`
   - `gitlab_runner_lock_to_project`  

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ gitlab_runner_description: >-
     {{ ansible_distribution_major_version }}
 gitlab_runner_tags: ['delegated']
 gitlab_runner_python_module_version: '1.12.1'
+gitlab_runner_access_level: not_protected
 gitlab_runner_untagged_builds_run: true
 gitlab_runner_lock_to_project: false
 gitlab_runner_executor: shell

--- a/tasks/config-gitlab-runner.yml
+++ b/tasks/config-gitlab-runner.yml
@@ -11,7 +11,9 @@
     registration_token: '{{ gitlab_ci_token }}'
     description: '{{ gitlab_runner_description }}'
     tag_list: '{{ gitlab_runner_tags }}'
+    access_level: '{{ gitlab_runner_access_level }}'
     run_untagged: '{{ gitlab_runner_untagged_builds_run }}'
+    locked: '{{ gitlab_runner_lock_to_project }}'
     state: present
   become: true
   register: gitlab_runner


### PR DESCRIPTION
## Description

Added ability to configure gitlab-runner access level and locked status 
Fixed `gitlab_runner_lock_to_project` variable work #19 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Reviews

- [x] @tgadiev 
- [x] @ignatovich-artem 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass with my changes
